### PR TITLE
Fix the Stack instantiation build error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [1.3.0] - 16 Sept 2020
+* Fix the breaking change introduced by https://github.com/flutter/flutter/commit/7948a7863bd8931e4e029c5b109f26c1b3dcf8ea and merged into flutter master by https://github.com/flutter/flutter/pull/61366 by replacing `overflow: Overflow.visible,` with `clipBehavior: Clip.none,` in the Stack object instantiation
 
 ## [1.2.5] - 07 Dec 2019
 

--- a/lib/src/speed_dial.dart
+++ b/lib/src/speed_dial.dart
@@ -246,7 +246,7 @@ class _SpeedDialState extends State<SpeedDial> with SingleTickerProviderStateMix
     return Stack(
       alignment: Alignment.bottomRight,
       fit: StackFit.expand,
-      overflow: Overflow.visible,
+      clipBehavior: Clip.none,
       children: children,
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_speed_dial
 description: Flutter plugin to implement a beautiful and dynamic Material Design Speed Dial, with labels, animated icons and hide on scrolling.
-version: 1.2.5
+version: 1.3.0
 author: Dario Ielardi <dario.ielardi@gmail.com>
 homepage: https://github.com/darioielardi/flutter_speed_dial
 


### PR DESCRIPTION
It seems as though as a result of https://github.com/flutter/flutter/commit/7948a7863bd8931e4e029c5b109f26c1b3dcf8ea#diff-7f71460835520a1820d69cd0b6994c01L3316 which was merged into flutter master in https://github.com/flutter/flutter/pull/61366

The `Stack` object removed the option for overflow and instead `clipBehavior` should be set to `Clip.none`

